### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ module.exports = SpriteMagicImporter({
 
 build.js
 
+**Plese note:** You cannot use `sass.renderSync` with this importer.
+
 ```js
 var sass = require('node-sass');
 var importer = require('./importer');


### PR DESCRIPTION
👋 This note in the README may help others avoid unexpected early termination of the node process when attempting to use `renderSync` (I did this with node-sass 4.12.0)